### PR TITLE
Fix build path entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "winamp2-js",
   "version": "0.0.1",
   "description": "Winamp 2 implemented in HTML5 and JavaScript",
-  "main": "build/winamp.bundle.js",
+  "main": "built/winamp.bundle.js",
   "scripts": {
     "lint": "eslint .",
     "build": "webpack --config=webpack.production.config.js",


### PR DESCRIPTION
It appears that the main entry point path is currently incorrect (resulting in failure to import the lib).