### PR TITLE
"Fix" color parsing

### DIFF
--- a/js/__tests__/fixtures/PLEDIT_WITH_QUOTES.TXT
+++ b/js/__tests__/fixtures/PLEDIT_WITH_QUOTES.TXT
@@ -1,0 +1,6 @@
+[Text]
+Normal= "#00FF00"
+Current= '#FFFFFF'
+NormalBG= "#000000"
+SelectedBG= "#0000FF"
+Font= "Ricky's cool font!"

--- a/js/actionCreators.js
+++ b/js/actionCreators.js
@@ -339,9 +339,9 @@ export function setSkinFromUrl(url) {
   };
 }
 
-export function openFileDialog() {
+export function openFileDialog(accept) {
   return async dispatch => {
-    const fileReferences = await promptForFileReferences();
+    const fileReferences = await promptForFileReferences(accept);
     dispatch(loadFilesFromReferences(fileReferences));
   };
 }

--- a/js/components/MainWindow/MainContextMenu.js
+++ b/js/components/MainWindow/MainContextMenu.js
@@ -18,7 +18,10 @@ const MainContextMenu = props => (
     <Hr />
     <Node onClick={props.openFileDialog} label="Play File..." />
     <Parent label="Skins">
-      <Node onClick={props.openFileDialog.bind(null, '.zip, .wsz')} label="Load Skin..." />
+      <Node
+        onClick={props.openFileDialog.bind(null, ".zip, .wsz")}
+        label="Load Skin..."
+      />
       {!!props.avaliableSkins.length && <Hr />}
       {props.avaliableSkins.map(skin => (
         <Node

--- a/js/components/MainWindow/MainContextMenu.js
+++ b/js/components/MainWindow/MainContextMenu.js
@@ -18,7 +18,7 @@ const MainContextMenu = props => (
     <Hr />
     <Node onClick={props.openFileDialog} label="Play File..." />
     <Parent label="Skins">
-      <Node onClick={props.openFileDialog} label="Load Skin..." />
+      <Node onClick={props.openFileDialog.bind(null, '.zip, .wsz')} label="Load Skin..." />
       {!!props.avaliableSkins.length && <Hr />}
       {props.avaliableSkins.map(skin => (
         <Node

--- a/js/fileUtils.js
+++ b/js/fileUtils.js
@@ -28,11 +28,14 @@ export async function genArrayBufferFromUrl(url) {
   });
 }
 
-export async function promptForFileReferences() {
+export async function promptForFileReferences(accept) {
   return new Promise(resolve => {
     // Does this represent a memory leak somehow?
     // Can this fail? Do we ever reject?
     const fileInput = document.createElement("input");
+    if (accept) {
+      fileInput.setAttribute('accept', accept)
+    }
     fileInput.type = "file";
     fileInput.multiple = true;
     // Not entirely sure why this is needed, since the input

--- a/js/fileUtils.js
+++ b/js/fileUtils.js
@@ -33,7 +33,7 @@ export async function promptForFileReferences(accept) {
     // Does this represent a memory leak somehow?
     // Can this fail? Do we ever reject?
     const fileInput = document.createElement("input");
-    if (accept) fileInput.setAttribute('accept', accept)
+    if (accept) fileInput.setAttribute("accept", accept)
     fileInput.type = "file";
     fileInput.multiple = true;
     // Not entirely sure why this is needed, since the input

--- a/js/fileUtils.js
+++ b/js/fileUtils.js
@@ -33,9 +33,7 @@ export async function promptForFileReferences(accept) {
     // Does this represent a memory leak somehow?
     // Can this fail? Do we ever reject?
     const fileInput = document.createElement("input");
-    if (accept) {
-      fileInput.setAttribute('accept', accept)
-    }
+    if (accept) fileInput.setAttribute('accept', accept)
     fileInput.type = "file";
     fileInput.multiple = true;
     // Not entirely sure why this is needed, since the input

--- a/js/fileUtils.js
+++ b/js/fileUtils.js
@@ -33,7 +33,7 @@ export async function promptForFileReferences(accept) {
     // Does this represent a memory leak somehow?
     // Can this fail? Do we ever reject?
     const fileInput = document.createElement("input");
-    if (accept) fileInput.setAttribute("accept", accept)
+    if (accept) fileInput.setAttribute("accept", accept);
     fileInput.type = "file";
     fileInput.multiple = true;
     // Not entirely sure why this is needed, since the input

--- a/js/utils.js
+++ b/js/utils.js
@@ -78,7 +78,7 @@ export const parseIni = text => {
   let section, match;
   return text.split(/[\r\n]+/g).reduce((data, line) => {
     if ((match = line.match(PROPERTY_REGEX)) && section != null) {
-      const value = match[2].replace(/("|')/gi, "");
+      const value = match[2].replace(/(^")|("$)|(^')|('$)/gi, "");
       data[section][match[1].trim().toLowerCase()] = value;
     } else if ((match = line.match(SECTION_REGEX))) {
       section = match[1].trim().toLowerCase();

--- a/js/utils.js
+++ b/js/utils.js
@@ -78,7 +78,7 @@ export const parseIni = text => {
   let section, match;
   return text.split(/[\r\n]+/g).reduce((data, line) => {
     if ((match = line.match(PROPERTY_REGEX)) && section != null) {
-      data[section][match[1].trim().toLowerCase()] = match[2];
+      data[section][match[1].trim().toLowerCase()] = match[2].replace(/("|')/, '');
     } else if ((match = line.match(SECTION_REGEX))) {
       section = match[1].trim().toLowerCase();
       data[section] = {};

--- a/js/utils.js
+++ b/js/utils.js
@@ -78,7 +78,8 @@ export const parseIni = text => {
   let section, match;
   return text.split(/[\r\n]+/g).reduce((data, line) => {
     if ((match = line.match(PROPERTY_REGEX)) && section != null) {
-      data[section][match[1].trim().toLowerCase()] = match[2].replace(/("|')/, '');
+      const value = match[2].replace(/("|')/, "");
+      data[section][match[1].trim().toLowerCase()] = value;
     } else if ((match = line.match(SECTION_REGEX))) {
       section = match[1].trim().toLowerCase();
       data[section] = {};

--- a/js/utils.js
+++ b/js/utils.js
@@ -78,7 +78,7 @@ export const parseIni = text => {
   let section, match;
   return text.split(/[\r\n]+/g).reduce((data, line) => {
     if ((match = line.match(PROPERTY_REGEX)) && section != null) {
-      const value = match[2].replace(/("|')/, "");
+      const value = match[2].replace(/("|')/gi, "");
       data[section][match[1].trim().toLowerCase()] = value;
     } else if ((match = line.match(SECTION_REGEX))) {
       section = match[1].trim().toLowerCase();

--- a/js/utils.test.js
+++ b/js/utils.test.js
@@ -144,6 +144,19 @@ bar = baz
     };
     expect(actual).toEqual(expected);
   });
+
+  it("allows quotes around values", () => {
+    const actual = parseIni(`
+[foo]
+bar = "baz"
+  `);
+    const expected = {
+      foo: {
+        bar: "baz"
+      }
+    };
+    expect(actual).toEqual(expected);
+  });
 });
 
 test("normalize", () => {

--- a/js/utils.test.js
+++ b/js/utils.test.js
@@ -145,6 +145,21 @@ bar = baz
     expect(actual).toEqual(expected);
   });
 
+  it("can parse a pledit.txt file with quotes", () => {
+    const pledit = fixture("PLEDIT_WITH_QUOTES.TXT");
+    const actual = parseIni(pledit);
+    const expected = {
+      text: {
+        normal: "#00FF00",
+        current: "#FFFFFF",
+        normalbg: "#000000",
+        selectedbg: "#0000FF",
+        font: "Ricky's cool font!"
+      }
+    };
+    expect(actual).toEqual(expected);
+  });
+
   it("allows quotes around values", () => {
     const actual = parseIni(`
 [foo]


### PR DESCRIPTION
re: #480 

so it would seem (for whatever reason, my guess is regEx needs to be tweaked?) some additional characters end up coming in when parsing pledit colors (it's possible this is happening for other parsed values also)...

colors to start vs colors when my skin is loaded/parsed:

<img width="433" alt="image" src="https://user-images.githubusercontent.com/675259/36072065-06c3a718-0ee7-11e8-91df-3a1c69ac2cbe.png">

now, I am not suggesting this is the "fix", this is merely my "first swing" to illustrate. but it did fix the initial issue:

<img width="605" alt="image" src="https://user-images.githubusercontent.com/675259/36072051-df7fb962-0ee6-11e8-899c-9e0fa1708723.png">

@captbaritone let me know what your thoughts are and how a better fix might be implemented/where that might go and I can update the PR

thanks!
